### PR TITLE
Dispose principal objects once we're done with them.

### DIFF
--- a/IronFrame/LocalUserGroupManager.cs
+++ b/IronFrame/LocalUserGroupManager.cs
@@ -18,8 +18,11 @@ namespace IronFrame
 
                 try
                 {
-                    DirectoryEntry group = children.Find(groupName);
-                    if (group != null) return;
+                    using (DirectoryEntry group = children.Find(groupName))
+                    {
+                        if (group != null)
+                            return;
+                    }
                 }
                 catch (COMException)
                 {
@@ -37,8 +40,10 @@ namespace IronFrame
             {
                 DirectoryEntries children = localDirectory.Children;
 
-                DirectoryEntry group = children.Find(groupName);
-                children.Remove(group);
+                using (DirectoryEntry group = children.Find(groupName))
+                {
+                    children.Remove(group);
+                }
             }
         }
     }


### PR DESCRIPTION
Making sure we don't lose the change from the old if_warden PR (https://github.com/cloudfoundry-incubator/if_warden/pull/17).  Most of the changes in that PR aren't necessary, but I didn't want to lose this one.