### PR TITLE
Fix tests that load the user's environment when running under the SYSTEM account

### DIFF
--- a/IronFrame.Test/ProcessRunnerTests.cs
+++ b/IronFrame.Test/ProcessRunnerTests.cs
@@ -252,9 +252,19 @@ namespace IronFrame
 
                 Assert.NotNull(p.Environment);
                 Assert.True(p.Environment.Count > 0);
-                Assert.Equal(WindowsIdentity.GetCurrent().GetUserName(), p.Environment["USERNAME"]);
+                Assert.Equal(GetCurrentUserName(), p.Environment["USERNAME"]);
             }
 
+            static string GetCurrentUserName()
+            {
+                // SYSTEM is a pseudo-user, the process is really running under the machine account 
+                // and the username is MACHINENAME$
+                var username = WindowsIdentity.GetCurrent().GetUserName();
+                if (username.Equals("SYSTEM", StringComparison.OrdinalIgnoreCase))
+                    return Environment.MachineName + "$";
+
+                return username;
+            }
         }
     }
 }

--- a/IronFrame.Test/Utilities/EnvironmentBlockTests.cs
+++ b/IronFrame.Test/Utilities/EnvironmentBlockTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Security.Principal;
 using Xunit;
@@ -42,7 +43,7 @@ namespace IronFrame.Utilities
         }
 
         [Fact]
-        public void GeneratesEnvironmentForUseToken()
+        public void GeneratesEnvironmentForUserToken()
         {
             var identity = WindowsIdentity.GetCurrent();
             var userToken = identity.Token;
@@ -50,7 +51,18 @@ namespace IronFrame.Utilities
             var env = EnvironmentBlock.CreateForUser(userToken);
             var dict = env.ToDictionary();
 
-            Assert.Equal(identity.GetUserName(), dict["USERNAME"]);
+            Assert.Equal(GetUserName(identity), dict["USERNAME"]);
+        }
+
+        static string GetUserName(WindowsIdentity identity)
+        {
+            // SYSTEM is a pseudo-user, the process is really running under the machine account 
+            // and the username is MACHINENAME$
+            var username = identity.GetUserName();
+            if (username.Equals("SYSTEM", StringComparison.OrdinalIgnoreCase))
+                return Environment.MachineName + "$";
+
+            return username;
         }
     }
 }


### PR DESCRIPTION
Our internal CI build runs under the Local System account and these tests fail.

On Windows, the SYSTEM account is a pseudo-user and the process is really running under the machine account.
