### PR TITLE
Implement IContainer#CreateFirewallRule

### DIFF
--- a/IronFrame.Test/ContainerTests.cs
+++ b/IronFrame.Test/ContainerTests.cs
@@ -423,7 +423,6 @@ namespace IronFrame
             public void DeletesFirewallRules()
             {
                 Container.Destroy();
-
                 TcpPortManager.Received(1).RemoveFirewallRules(User.UserName);
             }
         }
@@ -647,17 +646,6 @@ namespace IronFrame
 
                 Assert.Equal(ContainerState.Stopped, info.State);
             }
-        }
-
-        public class BlockAllOutboundConnections : ContainerTests
-        {
-            [Fact]
-            public void DelegatesToLocalTcpPortManager()
-            {
-                Container.BlockAllOutBoundConnections();
-                TcpPortManager.Received(1).BlockAllOutboundConnections(User.UserName);
-            }
-            
         }
     }
 }

--- a/IronFrame.Test/ContainerTests.cs
+++ b/IronFrame.Test/ContainerTests.cs
@@ -418,6 +418,14 @@ namespace IronFrame
 
                 ProcessRunner.Received(1).Dispose();
             }
+
+            [Fact]
+            public void DeletesFirewallRules()
+            {
+                Container.Destroy();
+
+                TcpPortManager.Received(1).RemoveFirewallRules(User.UserName);
+            }
         }
 
         public class GetInfo : ContainerTests
@@ -641,8 +649,15 @@ namespace IronFrame
             }
         }
 
-        public class Dispose : ContainerTests
+        public class BlockAllOutboundConnections : ContainerTests
         {
+            [Fact]
+            public void DelegatesToLocalTcpPortManager()
+            {
+                Container.BlockAllOutBoundConnections();
+                TcpPortManager.Received(1).BlockAllOutboundConnections(User.UserName);
+            }
+            
         }
     }
 }

--- a/IronFrame.Test/FirewallRuleSpecTest.cs
+++ b/IronFrame.Test/FirewallRuleSpecTest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IronFrame
+{
+    public class FirewallRuleSpecTest
+    {
+        [Fact]
+        public void TestRemoteAddresses()
+        {
+            var firewallRuleSpec = new FirewallRuleSpec()
+            {
+                Networks = new List<IPRange>
+                {
+                    new IPRange {Start = "10.1.1.1", End = "10.1.1.10"},
+                    new IPRange {Start = "10.3.1.1", End = "10.3.1.10"}
+
+                }
+            };
+            Assert.Equal("10.1.1.1-10.1.1.10,10.3.1.1-10.3.1.10", firewallRuleSpec.RemoteAddresses);
+        }
+    }
+}

--- a/IronFrame.Test/FirewallRuleSpecTest.cs
+++ b/IronFrame.Test/FirewallRuleSpecTest.cs
@@ -9,6 +9,7 @@ namespace IronFrame
 {
     public class FirewallRuleSpecTest
     {
+
         [Fact]
         public void TestRemoteAddresses()
         {
@@ -22,6 +23,42 @@ namespace IronFrame
                 }
             };
             Assert.Equal("10.1.1.1-10.1.1.10,10.3.1.1-10.3.1.10", firewallRuleSpec.RemoteAddresses);
+        }
+
+        [Fact]
+        public void TestRemotePorts()
+        {
+            var firewallRuleSpec = new FirewallRuleSpec()
+            {
+                Ports = new List<PortRange>
+                {
+                    new PortRange() {Start = 8080, End = 8090},
+                    new PortRange() {Start = 9090, End = 9099},
+
+                }
+            };
+            Assert.Equal("8080-8090,9090-9099", firewallRuleSpec.RemotePorts);
+        }
+
+        [Fact]
+        public void ReturnStartIfAddressesIsEmpty()
+        {
+            var firewallRuleSpec = new FirewallRuleSpec();
+            Assert.Equal("*", firewallRuleSpec.RemoteAddresses);
+        }
+
+        [Fact]
+        public void ReturnStartIfPortIsEmpty()
+        {
+            var firewallRuleSpec = new FirewallRuleSpec();
+            Assert.Equal("*", firewallRuleSpec.RemotePorts);
+        }
+
+        [Fact]
+        public void InitializeProtocolToTcp()
+        {
+            var firewallRuleSpec = new FirewallRuleSpec();
+            Assert.Equal(Protocol.All, firewallRuleSpec.Protocol);
         }
     }
 }

--- a/IronFrame.Test/FirewallRuleSpecTest.cs
+++ b/IronFrame.Test/FirewallRuleSpecTest.cs
@@ -41,21 +41,21 @@ namespace IronFrame
         }
 
         [Fact]
-        public void ReturnStartIfAddressesIsEmpty()
+        public void ReturnStarIfAddressesIsEmpty()
         {
             var firewallRuleSpec = new FirewallRuleSpec();
             Assert.Equal("*", firewallRuleSpec.RemoteAddresses);
         }
 
         [Fact]
-        public void ReturnStartIfPortIsEmpty()
+        public void ReturnStarIfPortIsEmpty()
         {
             var firewallRuleSpec = new FirewallRuleSpec();
             Assert.Equal("*", firewallRuleSpec.RemotePorts);
         }
 
         [Fact]
-        public void InitializeProtocolToTcp()
+        public void InitializeProtocolToAll()
         {
             var firewallRuleSpec = new FirewallRuleSpec();
             Assert.Equal(Protocol.All, firewallRuleSpec.Protocol);

--- a/IronFrame.Test/IronFrame.Test.csproj
+++ b/IronFrame.Test/IronFrame.Test.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Interop.NetFwTypeLib">
+      <HintPath>..\IronFrame.Shared\obj\Debug\Interop.NetFwTypeLib.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -101,10 +105,11 @@
     <Compile Include="TestSupport\NSubstituteExtensions.cs" />
     <Compile Include="TestSupport\TempFile.cs" />
     <Compile Include="Utilities\FileSystemSecurityDescriptorReaderTests.cs" />
+    <Compile Include="Utilities\FirewallManagerTests.cs" />
     <Compile Include="Utilities\JobObjectLimitsTests.cs" />
     <Compile Include="Utilities\JobObjectTests.cs" />
     <Compile Include="Utilities\LocalPrincipalManagerTests.cs" />
-    <Compile Include="Utilities\LocalTcpPortManagerTests.cs" />
+    <Compile Include="LocalTcpPortManagerTests.cs" />
     <Compile Include="Utilities\ProcessHelperTest.cs" />
     <Compile Include="ProcessRunnerTests.cs" />
     <Compile Include="ProcessTrackerTests.cs" />

--- a/IronFrame.Test/IronFrame.Test.csproj
+++ b/IronFrame.Test/IronFrame.Test.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ContainerProcessTests.cs" />
     <Compile Include="ContainerTests.cs" />
     <Compile Include="ContainerUserTests.cs" />
+    <Compile Include="FirewallRuleSpecTest.cs" />
     <Compile Include="Handlers\StopProcessHandlerTests.cs" />
     <Compile Include="Internal\LocalFilePropertyServiceTests.cs" />
     <Compile Include="Messaging\MessageDispatcherTest.cs" />

--- a/IronFrame.Test/IronFrame.Test.csproj
+++ b/IronFrame.Test/IronFrame.Test.csproj
@@ -33,10 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Interop.NetFwTypeLib">
-      <HintPath>..\IronFrame.Shared\obj\Debug\Interop.NetFwTypeLib.dll</HintPath>
+    <COMReference Include="NetFwTypeLib">
+      <Guid>{58FBCF7C-E7A9-467C-80B3-FC65E8FCCA08}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
+    </COMReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/IronFrame.Test/LocalTcpPortManagerTests.cs
+++ b/IronFrame.Test/LocalTcpPortManagerTests.cs
@@ -137,7 +137,7 @@ namespace IronFrame
             public void DelegatesToFirewallManager()
             {
                 var tcpPortManager = new LocalTcpPortManager(FirewallManager, NetShRunner);
-                var firewallRuleSpec = Substitute.For<FirewallRuleSpec>();
+                var firewallRuleSpec = new FirewallRuleSpec();
                 tcpPortManager.CreateFirewallRule("fred", firewallRuleSpec);
                 FirewallManager.Received(1).CreateFirewallRule("fred", firewallRuleSpec);
             }

--- a/IronFrame.Test/LocalTcpPortManagerTests.cs
+++ b/IronFrame.Test/LocalTcpPortManagerTests.cs
@@ -131,14 +131,15 @@ namespace IronFrame
             }
         }
 
-        public class BlockOutgoingConnections : LocalTcpPortManagerTests
+        public class CreateFirewallRule : LocalTcpPortManagerTests
         {
             [Fact]
             public void DelegatesToFirewallManager()
             {
                 var tcpPortManager = new LocalTcpPortManager(FirewallManager, NetShRunner);
-                tcpPortManager.BlockAllOutboundConnections("fred");
-                FirewallManager.Received(1).BlockAllOutboundConnections("fred");
+                var firewallRuleSpec = Substitute.For<FirewallRuleSpec>();
+                tcpPortManager.CreateFirewallRule("fred", firewallRuleSpec);
+                FirewallManager.Received(1).CreateFirewallRule("fred", firewallRuleSpec);
             }
         }
 

--- a/IronFrame.Test/LocalTcpPortManagerTests.cs
+++ b/IronFrame.Test/LocalTcpPortManagerTests.cs
@@ -131,15 +131,15 @@ namespace IronFrame
             }
         }
 
-        public class CreateFirewallRule : LocalTcpPortManagerTests
+        public class CreateOutboundFirewallRule : LocalTcpPortManagerTests
         {
             [Fact]
             public void DelegatesToFirewallManager()
             {
                 var tcpPortManager = new LocalTcpPortManager(FirewallManager, NetShRunner);
                 var firewallRuleSpec = new FirewallRuleSpec();
-                tcpPortManager.CreateFirewallRule("fred", firewallRuleSpec);
-                FirewallManager.Received(1).CreateFirewallRule("fred", firewallRuleSpec);
+                tcpPortManager.CreateOutboundFirewallRule("fred", firewallRuleSpec);
+                FirewallManager.Received(1).CreateOutboundFirewallRule("fred", firewallRuleSpec);
             }
         }
 

--- a/IronFrame.Test/LocalTcpPortManagerTests.cs
+++ b/IronFrame.Test/LocalTcpPortManagerTests.cs
@@ -130,5 +130,27 @@ namespace IronFrame
                 Assert.IsType<Exception>(exception);
             }
         }
+
+        public class BlockOutgoingConnections : LocalTcpPortManagerTests
+        {
+            [Fact]
+            public void DelegatesToFirewallManager()
+            {
+                var tcpPortManager = new LocalTcpPortManager(FirewallManager, NetShRunner);
+                tcpPortManager.BlockAllOutboundConnections("fred");
+                FirewallManager.Received(1).BlockAllOutboundConnections("fred");
+            }
+        }
+
+        public class RemoveFirewallRules : LocalTcpPortManagerTests
+        {
+            [Fact]
+            public void DelegatesToFirewallManager()
+            {
+                var tcpPortManager = new LocalTcpPortManager(FirewallManager, NetShRunner);
+                tcpPortManager.RemoveFirewallRules("fred");
+                FirewallManager.Received(1).RemoveAllFirewallRules("fred");
+            }
+        }
     }
 }

--- a/IronFrame.Test/Utilities/FirewallManagerTests.cs
+++ b/IronFrame.Test/Utilities/FirewallManagerTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NetFwTypeLib;
+using Xunit;
+
+namespace IronFrame.Utilities
+{
+    public class FirewallManagerTests
+    {
+        private const string Username = "Administrator";
+        readonly FirewallManager manager = new FirewallManager();
+        readonly INetFwPolicy2 firewallPolicy =
+               (INetFwPolicy2)Activator.CreateInstance(Type.GetTypeFromProgID("HNetCfg.FwPolicy2"));
+
+        [FactAdminRequired]
+        public void BlocksAllConnections()
+        {
+            try
+            {
+                manager.BlockAllOutboundConnections(Username);
+                var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
+                Assert.NotNull(rule);
+                Assert.Equal(rule.Action, NET_FW_ACTION_.NET_FW_ACTION_BLOCK);
+                Assert.Equal(rule.LocalUserAuthorizedList, FirewallManager.GetFormattedLocalUserSid(Username));
+            }
+            finally
+            {
+                firewallPolicy.Rules.Remove(Username);
+                Assert.Throws<FileNotFoundException>(() => firewallPolicy.Rules.Item(Username));
+            }
+        }
+
+        [FactAdminRequired]
+        public void RemoveFirewallRules()
+        {
+            manager.BlockAllOutboundConnections(Username);
+            // windows allow more than one rule to be added with the same name
+            manager.BlockAllOutboundConnections(Username);
+            manager.RemoveAllFirewallRules(Username);
+            Assert.Throws<FileNotFoundException>(() => firewallPolicy.Rules.Item(Username));
+        }
+    }
+}

--- a/IronFrame.Test/Utilities/FirewallManagerTests.cs
+++ b/IronFrame.Test/Utilities/FirewallManagerTests.cs
@@ -75,8 +75,8 @@ namespace IronFrame.Utilities
                 manager.CreateOutboundFirewallRule(Username, firewallRuleSpec);
                 var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                 CheckCommonRuleProperties(rule);
-                Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
-                Assert.Equal(firewallRuleSpec.RemoteAddresses, rule.RemoteAddresses);
+                Assert.Equal((int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP, rule.Protocol);
+                Assert.Equal("10.1.1.1-10.1.10.10", rule.RemoteAddresses);
                 Assert.Equal("*", rule.RemotePorts);
             }
 
@@ -94,9 +94,9 @@ namespace IronFrame.Utilities
                 manager.CreateOutboundFirewallRule(Username, firewallSpec);
                 var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                 CheckCommonRuleProperties(rule);
-                Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
+                Assert.Equal((int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP, rule.Protocol);
                 Assert.Equal("*", rule.RemoteAddresses);
-                Assert.Equal(firewallSpec.RemotePorts, rule.RemotePorts);
+                Assert.Equal("8080-8090", rule.RemotePorts);
             }
 
             [FactAdminRequired]
@@ -118,9 +118,9 @@ namespace IronFrame.Utilities
                 manager.CreateOutboundFirewallRule(Username, firewallSpec);
                 var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                 CheckCommonRuleProperties(rule);
-                Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
-                Assert.Equal(firewallSpec.RemoteAddresses, rule.RemoteAddresses);
-                Assert.Equal(firewallSpec.RemotePorts, rule.RemotePorts);
+                Assert.Equal((int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP, rule.Protocol);
+                Assert.Equal("10.1.1.1-10.1.1.100", rule.RemoteAddresses);
+                Assert.Equal("8080-8090", rule.RemotePorts);
             }
         }
 
@@ -142,16 +142,16 @@ namespace IronFrame.Utilities
                 // On windows we have to create two rules one for tcp and another for udp
                 var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                 CheckCommonRuleProperties(rule);
-                Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
-                Assert.Equal(firewallSpec.RemoteAddresses, rule.RemoteAddresses);
-                Assert.Equal(firewallSpec.RemotePorts, rule.RemotePorts);
+                Assert.Equal((int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP, rule.Protocol);
+                Assert.Equal("*", rule.RemoteAddresses);
+                Assert.Equal("8080-8090", rule.RemotePorts);
                 firewallPolicy.Rules.Remove(Username);
 
                 rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                 CheckCommonRuleProperties(rule);
-                Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP);
-                Assert.Equal(firewallSpec.RemoteAddresses, rule.RemoteAddresses);
-                Assert.Equal(firewallSpec.RemotePorts, rule.RemotePorts);
+                Assert.Equal((int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP, rule.Protocol);
+                Assert.Equal("*", rule.RemoteAddresses);
+                Assert.Equal("8080-8090", rule.RemotePorts);
             }
         };
 
@@ -176,9 +176,9 @@ namespace IronFrame.Utilities
                 manager.CreateOutboundFirewallRule(Username, firewallSpec);
                 var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                 CheckCommonRuleProperties(rule);
-                Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP);
-                Assert.Equal(firewallSpec.RemoteAddresses, rule.RemoteAddresses);
-                Assert.Equal(firewallSpec.RemotePorts, rule.RemotePorts);
+                Assert.Equal((int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP, rule.Protocol);
+                Assert.Equal("10.1.1.1-10.1.1.100", rule.RemoteAddresses);
+                Assert.Equal("8080-8090", rule.RemotePorts);
             }
         };
 

--- a/IronFrame.Test/Utilities/FirewallManagerTests.cs
+++ b/IronFrame.Test/Utilities/FirewallManagerTests.cs
@@ -34,7 +34,7 @@ namespace IronFrame.Utilities
             {
                 try
                 {
-                    manager.CreateFirewallRule(Username, new FirewallRuleSpec
+                    manager.CreateOutboundFirewallRule(Username, new FirewallRuleSpec
                     {
                         Protocol =  Protocol.Tcp,
                     });
@@ -63,7 +63,7 @@ namespace IronFrame.Utilities
                             new IPRange {Start = "10.1.1.1", End = "10.1.10.10"}
                         }
                     };
-                    manager.CreateFirewallRule(Username, firewallRuleSpec);
+                    manager.CreateOutboundFirewallRule(Username, firewallRuleSpec);
                     var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                     CheckCommonRuleProperties(rule);
                     Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
@@ -89,7 +89,7 @@ namespace IronFrame.Utilities
                 };
                 try
                 {
-                    manager.CreateFirewallRule(Username, firewallSpec);
+                    manager.CreateOutboundFirewallRule(Username, firewallSpec);
                     var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                     CheckCommonRuleProperties(rule);
                     Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
@@ -120,7 +120,7 @@ namespace IronFrame.Utilities
                         }
 
                     };
-                    manager.CreateFirewallRule(Username, firewallSpec);
+                    manager.CreateOutboundFirewallRule(Username, firewallSpec);
                     var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                     CheckCommonRuleProperties(rule);
                     Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
@@ -150,7 +150,7 @@ namespace IronFrame.Utilities
                             new PortRange {Start = 8080, End = 8090},
                         },
                     };
-                    manager.CreateFirewallRule(Username, firewallSpec);
+                    manager.CreateOutboundFirewallRule(Username, firewallSpec);
 
                     // On windows we have to create two rules one for tcp and another for udp
                     var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
@@ -195,7 +195,7 @@ namespace IronFrame.Utilities
                         }
 
                     };
-                    manager.CreateFirewallRule(Username, firewallSpec);
+                    manager.CreateOutboundFirewallRule(Username, firewallSpec);
                     var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                     CheckCommonRuleProperties(rule);
                     Assert.Equal(rule.Protocol, (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP);
@@ -215,7 +215,7 @@ namespace IronFrame.Utilities
             [FactAdminRequired]
             public void RemoveFirewallRules()
             {
-                manager.CreateFirewallRule(Username, new FirewallRuleSpec());
+                manager.CreateOutboundFirewallRule(Username, new FirewallRuleSpec());
                 manager.RemoveAllFirewallRules(Username);
                 Assert.Throws<FileNotFoundException>(() => firewallPolicy.Rules.Item(Username));
             }

--- a/IronFrame.Test/Utilities/FirewallManagerTests.cs
+++ b/IronFrame.Test/Utilities/FirewallManagerTests.cs
@@ -15,31 +15,39 @@ namespace IronFrame.Utilities
         readonly FirewallManager manager = new FirewallManager();
         readonly INetFwPolicy2 firewallPolicy =
                (INetFwPolicy2)Activator.CreateInstance(Type.GetTypeFromProgID("HNetCfg.FwPolicy2"));
+        readonly FirewallRuleSpec firewallRuleSpec = new FirewallRuleSpec
+        {
+            Networks = new List<IPRange>
+            {
+                new IPRange { Start = "10.1.1.1", End = "10.1.10.10" }
+            }
+        };
 
         [FactAdminRequired]
-        public void BlocksAllConnections()
+        public void CreateFirewallRule()
         {
             try
             {
-                manager.BlockAllOutboundConnections(Username);
+                manager.CreateFirewallRule(Username, firewallRuleSpec);
                 var rule = (INetFwRule3)firewallPolicy.Rules.Item(Username);
                 Assert.NotNull(rule);
-                Assert.Equal(rule.Action, NET_FW_ACTION_.NET_FW_ACTION_BLOCK);
+                Assert.Equal(rule.Action, NET_FW_ACTION_.NET_FW_ACTION_ALLOW);
+                Assert.Equal(rule.Direction, NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_OUT);
+                Assert.Equal(rule.Enabled, true);
                 Assert.Equal(rule.LocalUserAuthorizedList, FirewallManager.GetFormattedLocalUserSid(Username));
+                Assert.Equal(rule.RemoteAddresses, firewallRuleSpec.RemoteAddresses);
             }
             finally
             {
                 firewallPolicy.Rules.Remove(Username);
-                Assert.Throws<FileNotFoundException>(() => firewallPolicy.Rules.Item(Username));
             }
         }
+
 
         [FactAdminRequired]
         public void RemoveFirewallRules()
         {
-            manager.BlockAllOutboundConnections(Username);
-            // windows allow more than one rule to be added with the same name
-            manager.BlockAllOutboundConnections(Username);
+            manager.CreateFirewallRule(Username, firewallRuleSpec);
             manager.RemoveAllFirewallRules(Username);
             Assert.Throws<FileNotFoundException>(() => firewallPolicy.Rules.Item(Username));
         }

--- a/IronFrame/Container.cs
+++ b/IronFrame/Container.cs
@@ -136,6 +136,7 @@ namespace IronFrame
             {
                 tcpPortManager.ReleaseLocalPort(port, user.UserName);
             }
+            tcpPortManager.RemoveFirewallRules(user.UserName);
 
             // BR - Unmap the mounted directories (Removes user ACLs)
             // BR - Delete the container directory
@@ -278,6 +279,11 @@ namespace IronFrame
         public int CurrentCpuLimit()
         {
             return jobObject.GetJobCpuLimit();
+        }
+
+        public void BlockAllOutBoundConnections()
+        {
+            tcpPortManager.BlockAllOutboundConnections(user.UserName);
         }
     }
 }

--- a/IronFrame/Container.cs
+++ b/IronFrame/Container.cs
@@ -160,9 +160,9 @@ namespace IronFrame
             return new ContainerProcess(process);
         }
 
-        public void CreateFirewallRule(FirewallRuleSpec firewallRuleSpec)
+        public void CreateOutboundFirewallRule(FirewallRuleSpec firewallRuleSpec)
         {
-            tcpPortManager.CreateFirewallRule(user.UserName, firewallRuleSpec);
+            tcpPortManager.CreateOutboundFirewallRule(user.UserName, firewallRuleSpec);
         }
 
         public ContainerInfo GetInfo()

--- a/IronFrame/Container.cs
+++ b/IronFrame/Container.cs
@@ -160,6 +160,11 @@ namespace IronFrame
             return new ContainerProcess(process);
         }
 
+        public void CreateFirewallRule(FirewallRuleSpec firewallRuleSpec)
+        {
+            tcpPortManager.CreateFirewallRule(user.UserName, firewallRuleSpec);
+        }
+
         public ContainerInfo GetInfo()
         {
             ThrowIfDestroyed();
@@ -279,11 +284,6 @@ namespace IronFrame
         public int CurrentCpuLimit()
         {
             return jobObject.GetJobCpuLimit();
-        }
-
-        public void BlockAllOutBoundConnections()
-        {
-            tcpPortManager.BlockAllOutboundConnections(user.UserName);
         }
     }
 }

--- a/IronFrame/FirewallRuleSpec.cs
+++ b/IronFrame/FirewallRuleSpec.cs
@@ -8,12 +8,42 @@ namespace IronFrame
 {
     public class FirewallRuleSpec
     {
+        public Protocol Protocol { get; set; }
+
         public List<IPRange> Networks { get; set; }
+
+        public List<PortRange> Ports { get; set; } 
 
         public string RemoteAddresses
         {
-            get { return String.Join(",", Networks.Select(x => x.Start + "-" + x.End)); }
+            get
+            {
+                if (Networks == null)
+                {
+                    return "*";
+                }
+
+                return String.Join(",", Networks.Select(x => x.Start + "-" + x.End));
+            }
         }
+
+        public string RemotePorts
+        {
+            get
+            {
+                if (Ports == null)
+                {
+                    return "*";
+                }
+
+                return String.Join(",", Ports.Select(x => x.Start + "-" + x.End));
+            }
+        }
+    }
+
+    public enum Protocol
+    {
+        All, Tcp, Udp
     }
 
     public class IPRange
@@ -21,4 +51,11 @@ namespace IronFrame
         public string Start { get; set; }
         public string End { get; set; }
     }
+
+    public class PortRange
+    {
+        public UInt16 Start { get; set; }
+        public UInt16 End { get; set; }
+    }
+
 }

--- a/IronFrame/FirewallRuleSpec.cs
+++ b/IronFrame/FirewallRuleSpec.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IronFrame
+{
+    public class FirewallRuleSpec
+    {
+        public List<IPRange> Networks { get; set; }
+
+        public string RemoteAddresses
+        {
+            get { return String.Join(",", Networks.Select(x => x.Start + "-" + x.End)); }
+        }
+    }
+
+    public class IPRange
+    {
+        public string Start { get; set; }
+        public string End { get; set; }
+    }
+}

--- a/IronFrame/FirewallRuleSpec.cs
+++ b/IronFrame/FirewallRuleSpec.cs
@@ -54,8 +54,8 @@ namespace IronFrame
 
     public class PortRange
     {
-        public UInt16 Start { get; set; }
-        public UInt16 End { get; set; }
+        public int Start { get; set; }
+        public int End { get; set; }
     }
 
 }

--- a/IronFrame/IContainer.cs
+++ b/IronFrame/IContainer.cs
@@ -22,6 +22,7 @@ namespace IronFrame
         Dictionary<string, string> GetProperties();
         void RemoveProperty(string name);
         void Destroy();
+        void BlockAllOutBoundConnections();
 
         //ContainerState State { get; }
         //void BindMounts(IEnumerable<BindMount> mounts);

--- a/IronFrame/IContainer.cs
+++ b/IronFrame/IContainer.cs
@@ -22,7 +22,6 @@ namespace IronFrame
         Dictionary<string, string> GetProperties();
         void RemoveProperty(string name);
         void Destroy();
-        void BlockAllOutBoundConnections();
 
         //ContainerState State { get; }
         //void BindMounts(IEnumerable<BindMount> mounts);
@@ -31,6 +30,7 @@ namespace IronFrame
         //void CopyFileOut(string sourceFilePath, string destinationFilePath);
         //void ExtractTarFile(string tarFilePath, string destinationPath, bool decompress);
         IContainerProcess FindProcessById(int id);
+        void CreateFirewallRule(FirewallRuleSpec firewallRuleSpec);
     }
 
     public interface IProcessIO

--- a/IronFrame/IContainer.cs
+++ b/IronFrame/IContainer.cs
@@ -30,7 +30,7 @@ namespace IronFrame
         //void CopyFileOut(string sourceFilePath, string destinationFilePath);
         //void ExtractTarFile(string tarFilePath, string destinationPath, bool decompress);
         IContainerProcess FindProcessById(int id);
-        void CreateFirewallRule(FirewallRuleSpec firewallRuleSpec);
+        void CreateOutboundFirewallRule(FirewallRuleSpec firewallRuleSpec);
     }
 
     public interface IProcessIO

--- a/IronFrame/IronFrame.csproj
+++ b/IronFrame/IronFrame.csproj
@@ -70,6 +70,7 @@
     <Compile Include="ContainerHostClient.cs" />
     <Compile Include="ContainerHostDependencyHelper.cs" />
     <Compile Include="ContainerHostService.cs" />
+    <Compile Include="FirewallRuleSpec.cs" />
     <Compile Include="Utilities\Clock.cs" />
     <Compile Include="ContainerProcess.cs" />
     <Compile Include="ContainerUser.cs" />

--- a/IronFrame/LocalTcpPortManager.cs
+++ b/IronFrame/LocalTcpPortManager.cs
@@ -8,6 +8,9 @@ namespace IronFrame
     {
         int ReserveLocalPort(int port, string userName);
         void ReleaseLocalPort(int? port, string userName);
+
+        void BlockAllOutboundConnections(string username);
+        void RemoveFirewallRules(string userName);
     }
 
     internal class LocalTcpPortManager : ILocalTcpPortManager
@@ -91,6 +94,16 @@ namespace IronFrame
                 throw new Exception(String.Format("Error removing firewall rule for port '{0}', user '{1}'", port, userName), ex);
             }
 
+        }
+
+        public void BlockAllOutboundConnections(string userName)
+        {
+            firewallManager.BlockAllOutboundConnections(userName);
+        }
+
+        public void RemoveFirewallRules(string userName)
+        {
+            firewallManager.RemoveAllFirewallRules(userName);
         }
     }
 }

--- a/IronFrame/LocalTcpPortManager.cs
+++ b/IronFrame/LocalTcpPortManager.cs
@@ -10,7 +10,7 @@ namespace IronFrame
         void ReleaseLocalPort(int? port, string userName);
 
         void RemoveFirewallRules(string userName);
-        void CreateFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec);
+        void CreateOutboundFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec);
     }
 
     internal class LocalTcpPortManager : ILocalTcpPortManager
@@ -101,9 +101,9 @@ namespace IronFrame
             firewallManager.RemoveAllFirewallRules(userName);
         }
 
-        public void CreateFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec)
+        public void CreateOutboundFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec)
         {
-            firewallManager.CreateFirewallRule(userName, firewallRuleSpec);
+            firewallManager.CreateOutboundFirewallRule(userName, firewallRuleSpec);
         }
     }
 }

--- a/IronFrame/LocalTcpPortManager.cs
+++ b/IronFrame/LocalTcpPortManager.cs
@@ -9,8 +9,8 @@ namespace IronFrame
         int ReserveLocalPort(int port, string userName);
         void ReleaseLocalPort(int? port, string userName);
 
-        void BlockAllOutboundConnections(string username);
         void RemoveFirewallRules(string userName);
+        void CreateFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec);
     }
 
     internal class LocalTcpPortManager : ILocalTcpPortManager
@@ -96,14 +96,14 @@ namespace IronFrame
 
         }
 
-        public void BlockAllOutboundConnections(string userName)
-        {
-            firewallManager.BlockAllOutboundConnections(userName);
-        }
-
         public void RemoveFirewallRules(string userName)
         {
             firewallManager.RemoveAllFirewallRules(userName);
+        }
+
+        public void CreateFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec)
+        {
+            firewallManager.CreateFirewallRule(userName, firewallRuleSpec);
         }
     }
 }

--- a/IronFrame/Utilities/FirewallManager.cs
+++ b/IronFrame/Utilities/FirewallManager.cs
@@ -69,7 +69,7 @@ namespace IronFrame.Utilities
         /// <param name="userName"></param>
         public void RemoveAllFirewallRules(string userName)
         {
-            var firewallPolicy = (INetFwPolicy2)Activator.CreateInstance(Type.GetTypeFromProgID(NetFwPolicy2ProgID));
+            var firewallPolicy = getComObject<INetFwPolicy2>(NetFwPolicy2ProgID);
             var rules = firewallPolicy.Rules;
             try
             {
@@ -93,21 +93,21 @@ namespace IronFrame.Utilities
             var protocol = firewallRuleSpec.Protocol;
             if (protocol == Protocol.All)
             {
-                _CreateFirewallRule(windowsUserName, Protocol.Udp, firewallRuleSpec);
-                _CreateFirewallRule(windowsUserName, Protocol.Tcp, firewallRuleSpec);
+                CreateFirewallRuleForProtocol(windowsUserName, Protocol.Udp, firewallRuleSpec);
+                CreateFirewallRuleForProtocol(windowsUserName, Protocol.Tcp, firewallRuleSpec);
             }
             else
             {
-                _CreateFirewallRule(windowsUserName, protocol, firewallRuleSpec);    
+                CreateFirewallRuleForProtocol(windowsUserName, protocol, firewallRuleSpec);    
             }
         }
 
-        private void _CreateFirewallRule(string windowsUserName, Protocol proto, FirewallRuleSpec firewallRuleSpec)
+        private void CreateFirewallRuleForProtocol(string windowsUserName, Protocol proto, FirewallRuleSpec firewallRuleSpec)
         {
-            var firewallPolicy = (INetFwPolicy2)Activator.CreateInstance(Type.GetTypeFromProgID(NetFwPolicy2ProgID));
+            var firewallPolicy = getComObject<INetFwPolicy2>(NetFwPolicy2ProgID);
 
             // This type is only avaible in Windows Server 2012
-            var rule = ((INetFwRule3)Activator.CreateInstance(Type.GetTypeFromProgID(NetFwRuleProgID)));
+            var rule = getComObject<INetFwRule3>(NetFwRuleProgID);
 
             rule.Name = windowsUserName;
             switch (proto)
@@ -119,7 +119,7 @@ namespace IronFrame.Utilities
                     rule.Protocol = (int)NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP;
                     break;
                 default:
-                    throw new Exception("Protocol " + firewallRuleSpec.Protocol + " is unknown");
+                    throw new Exception("Protocol " + proto + " is unknown");
             }
             rule.Action = NET_FW_ACTION_.NET_FW_ACTION_ALLOW;
             rule.Direction = NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_OUT;

--- a/IronFrame/Utilities/FirewallManager.cs
+++ b/IronFrame/Utilities/FirewallManager.cs
@@ -13,7 +13,7 @@ namespace IronFrame.Utilities
         void OpenPort(int port, string name);
         void ClosePort(string name);
         void RemoveAllFirewallRules(string userName);
-        void CreateFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec);
+        void CreateOutboundFirewallRule(string userName, FirewallRuleSpec firewallRuleSpec);
     }
 
     /// <summary>
@@ -89,7 +89,7 @@ namespace IronFrame.Utilities
             }
         }
 
-        public void CreateFirewallRule(string windowsUserName, FirewallRuleSpec firewallRuleSpec)
+        public void CreateOutboundFirewallRule(string windowsUserName, FirewallRuleSpec firewallRuleSpec)
         {
             var protocol = firewallRuleSpec.Protocol;
             if (protocol == Protocol.All)

--- a/IronFrame/Utilities/FirewallManager.cs
+++ b/IronFrame/Utilities/FirewallManager.cs
@@ -76,7 +76,8 @@ namespace IronFrame.Utilities
                 // keep deleting until an exception is thrown
                 while (true)
                 {
-                    // rules.Item will throw an exception if the rule isn't found 
+                    // We need to call rules.Item() since rules.Remove() doesn't and silently return but 
+                    // rules.Item() will throw an exception.
                     rules.Item(userName);
                     rules.Remove(userName);
                 }

--- a/IronFrame/Utilities/FirewallManager.cs
+++ b/IronFrame/Utilities/FirewallManager.cs
@@ -76,8 +76,9 @@ namespace IronFrame.Utilities
                 // keep deleting until an exception is thrown
                 while (true)
                 {
-                    // We need to call rules.Item() since rules.Remove() doesn't and silently return but 
-                    // rules.Item() will throw an exception.
+                    // We need to call rules.Item() since
+                    // rules.Remove() silently returns but rules.Item()
+                    // will throw an exception.
                     rules.Item(userName);
                     rules.Remove(userName);
                 }


### PR DESCRIPTION
It turns out that windows apply firewall rules in a crappy order (block
rules take precendence over allow rules). That means we can't add a
block all rule followed by allow certains ports rule. The way to go here
is to set the default behavior of the firewall to block all outgoing
connections and IronFrame will add rules as needed when
CreateFirewallRule is called.

**NOTE**: we are having trouble building the project using msbuild. @brannon do you have any idea how to fix it ? That said the test suite is green when run under visual studio.