### PR TITLE
Process Limits

### DIFF
--- a/IronFrame.Shared/Utilities/IProcessRunner.cs
+++ b/IronFrame.Shared/Utilities/IProcessRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 
 namespace IronFrame.Utilities
@@ -32,5 +33,6 @@ namespace IronFrame.Utilities
 
         public Action<string> OutputCallback { get; set; }
         public Action<string> ErrorCallback { get; set; }
+        public ProcessPriorityClass PriorityClass { get; set; }
     }
 }

--- a/IronFrame.Shared/Utilities/JobObject.cs
+++ b/IronFrame.Shared/Utilities/JobObject.cs
@@ -380,5 +380,15 @@ namespace IronFrame.Utilities
                 return (int)allocation.ToStructure().CpuRate;
             }
         }
+
+        public virtual void SetPriorityClass(ProcessPriorityClass c)
+        {
+            var extendedLimit = GetJobLimits();
+
+            extendedLimit.BasicLimitInformation.LimitFlags |= NativeMethods.JobObjectLimit.PriorityClass;
+            extendedLimit.BasicLimitInformation.PriorityClass = (uint)c;
+
+            SetJobLimits(extendedLimit);
+        }
     }
 }

--- a/IronFrame.Shared/Utilities/JobObject.cs
+++ b/IronFrame.Shared/Utilities/JobObject.cs
@@ -313,6 +313,16 @@ namespace IronFrame.Utilities
             SetJobLimits(extendedLimit);
         }
 
+        public void SetActiveProcessLimit(uint activeProcessLimit)
+        {
+            var extendedLimit = GetJobLimits();
+
+            extendedLimit.BasicLimitInformation.LimitFlags |= NativeMethods.JobObjectLimit.ActiveProcess;
+            extendedLimit.BasicLimitInformation.ActiveProcessLimit = activeProcessLimit;
+
+            SetJobLimits(extendedLimit);
+        }
+
         public virtual void TerminateProcesses()
         {
             if (handle == null) { throw new ObjectDisposedException("JobObject"); }

--- a/IronFrame.Shared/Utilities/JobObject.cs
+++ b/IronFrame.Shared/Utilities/JobObject.cs
@@ -313,7 +313,7 @@ namespace IronFrame.Utilities
             SetJobLimits(extendedLimit);
         }
 
-        public void SetActiveProcessLimit(uint activeProcessLimit)
+        public virtual void SetActiveProcessLimit(uint activeProcessLimit)
         {
             var extendedLimit = GetJobLimits();
 
@@ -352,11 +352,11 @@ namespace IronFrame.Utilities
         }
 
 
-        public void SetJobCpuLimit(int cpuRate)
+        public virtual void SetJobCpuLimit(int cpuRate)
         {
             if (cpuRate < 1 || cpuRate > 10000) // 100% is 100 * 100 == 10000
             {
-                throw new ArgumentOutOfRangeException("cpuRate", cpuRate, "CPU Limit must be between 1 and 9");
+                throw new ArgumentOutOfRangeException("cpuRate", cpuRate, "CPU Limit must be between 1 and 10,000");
             }
             var cpuRateInfo = new NativeMethods.JobObjectCpuRateControlInformation
             {

--- a/IronFrame.Shared/Utilities/JobObject.cs
+++ b/IronFrame.Shared/Utilities/JobObject.cs
@@ -342,18 +342,18 @@ namespace IronFrame.Utilities
         }
 
 
-        public void SetJobCpuLimit(int weight)
+        public void SetJobCpuLimit(int cpuRate)
         {
-            if (weight < 1 || weight > 9)
+            if (cpuRate < 1 || cpuRate > 10000) // 100% is 100 * 100 == 10000
             {
-                throw new ArgumentOutOfRangeException("weight", weight, "CPU Limit must be between 1 and 9");
+                throw new ArgumentOutOfRangeException("cpuRate", cpuRate, "CPU Limit must be between 1 and 9");
             }
-            var cpuRate = new NativeMethods.JobObjectCpuRateControlInformation
+            var cpuRateInfo = new NativeMethods.JobObjectCpuRateControlInformation
             {
-                ControlFlags = (UInt32)(NativeMethods.JobObjectCpuRateControl.Enable | NativeMethods.JobObjectCpuRateControl.WeightBased),
-                Weight = (UInt32)weight,
+                ControlFlags = (UInt32)(NativeMethods.JobObjectCpuRateControl.Enable | NativeMethods.JobObjectCpuRateControl.HardCap),
+                CpuRate = (UInt32)cpuRate,
             };
-            using (var allocation = SafeAllocation.Create<NativeMethods.JobObjectCpuRateControlInformation>(cpuRate))
+            using (var allocation = SafeAllocation.Create<NativeMethods.JobObjectCpuRateControlInformation>(cpuRateInfo))
             {
                 if (!NativeMethods.SetInformationJobObject(handle, NativeMethods.JobObjectInfoClass.CpuRateControlInformation, allocation.DangerousGetHandle(), allocation.Size))
                     throw Win32LastError("Unable to query Cpu rate information");
@@ -367,7 +367,7 @@ namespace IronFrame.Utilities
                 if (!NativeMethods.QueryInformationJobObject(handle, NativeMethods.JobObjectInfoClass.CpuRateControlInformation, allocation.DangerousGetHandle(), allocation.Size, IntPtr.Zero))
                     throw Win32LastError("Unable to query Cpu rate information");
 
-                return (int)allocation.ToStructure().Weight;
+                return (int)allocation.ToStructure().CpuRate;
             }
         }
     }

--- a/IronFrame.Shared/Win32/JobObject.cs
+++ b/IronFrame.Shared/Win32/JobObject.cs
@@ -145,7 +145,7 @@ namespace IronFrame.Win32
             public UIntPtr MinimumWorkingSetSize;
             public UIntPtr MaximumWorkingSetSize;
             public UInt32 ActiveProcessLimit;
-            public Int64 Affinity;
+            public UIntPtr Affinity;
             public UInt32 PriorityClass;
             public UInt32 SchedulingClass;
         }

--- a/IronFrame.Test/ContainerTests.cs
+++ b/IronFrame.Test/ContainerTests.cs
@@ -58,6 +58,17 @@ namespace IronFrame
                 ContainerEnvironment);
         }
 
+        public class SetActiveProcessLimit : ContainerTests
+        {
+            [Fact]
+            public void ProxiesToJobObject()
+            {
+                uint processLimit = 8765;
+                this.Container.SetActiveProcessLimit(processLimit);
+                JobObject.Received(1).SetActiveProcessLimit(processLimit);
+            }
+        }
+
         public class GetProperty : ContainerTests
         {
             public GetProperty()

--- a/IronFrame.Test/ContainerTests.cs
+++ b/IronFrame.Test/ContainerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using IronFrame.Utilities;
 using NSubstitute;
@@ -66,6 +67,17 @@ namespace IronFrame
                 uint processLimit = 8765;
                 this.Container.SetActiveProcessLimit(processLimit);
                 JobObject.Received(1).SetActiveProcessLimit(processLimit);
+            }
+        }
+
+        public class SetProcessPriority : ContainerTests
+        {
+            [Fact]
+            public void ProxiesToJobObject()
+            {
+                var priority = ProcessPriorityClass.RealTime;
+                this.Container.SetPriorityClass(priority);
+                JobObject.Received(1).SetPriorityClass(priority);
             }
         }
 

--- a/IronFrame.Test/Utilities/JobObjectTests.cs
+++ b/IronFrame.Test/Utilities/JobObjectTests.cs
@@ -289,6 +289,30 @@ namespace IronFrame.Utilities
             }
 
             [Fact]
+            public void CanSetPriority()
+            {
+                jobObject.SetPriorityClass(ProcessPriorityClass.Idle);
+                jobObject2.SetPriorityClass(ProcessPriorityClass.Normal);
+
+                var thread1 = new Thread(() =>
+                {
+                    IFTestHelper.ExecuteInJob(jobObject, "consume-cpu", "--duration", "2000").WaitForExit();
+                });
+                var thread2 = new Thread(() =>
+                {
+                    IFTestHelper.ExecuteInJob(jobObject2, "consume-cpu", "--duration", "2000").WaitForExit();
+                });
+
+                thread1.Start();
+                thread2.Start();
+                thread1.Join();
+                thread2.Join();
+
+                var ratio = (float)jobObject.GetCpuStatistics().TotalUserTime.Ticks / jobObject2.GetCpuStatistics().TotalUserTime.Ticks;
+                Assert.InRange(ratio, 0.01, 0.7);
+            }
+
+            [Fact]
             public void CanGetCpuLimit()
             {
                 jobObject.SetJobCpuLimit(3);

--- a/IronFrame.Test/Utilities/JobObjectTests.cs
+++ b/IronFrame.Test/Utilities/JobObjectTests.cs
@@ -164,14 +164,12 @@ namespace IronFrame.Utilities
             {
                 var t = new Thread(() =>
                 {
-                    jobObject.SetActiveProcessLimit(7);
+                    jobObject.SetActiveProcessLimit(2);
 
-                    var process = IFTestHelper.ExecuteInJob(jobObject, "fork-bomb");
-
-                    Assert.True(IFTestHelper.Failed(process));
+                    IFTestHelper.ExecuteInJob(jobObject, "fork-bomb");
                 });
                 t.Start();
-                if (!t.Join(TimeSpan.FromSeconds(10)))
+                if (!t.Join(TimeSpan.FromSeconds(1)))
                 {
                     t.Abort();
                     Assert.True(false, "ForkBomb was not terminated");
@@ -309,7 +307,7 @@ namespace IronFrame.Utilities
                 thread2.Join();
 
                 var ratio = (float)jobObject.GetCpuStatistics().TotalUserTime.Ticks / jobObject2.GetCpuStatistics().TotalUserTime.Ticks;
-                Assert.InRange(ratio, 0.01, 0.7);
+                Assert.InRange(ratio, 0.01, 0.3);
             }
 
             [Fact]

--- a/IronFrame.Test/Utilities/JobObjectTests.cs
+++ b/IronFrame.Test/Utilities/JobObjectTests.cs
@@ -245,8 +245,8 @@ namespace IronFrame.Utilities
             [Fact]
             public void CanLimitCpu()
             {
-                jobObject.SetJobCpuLimit(1);
-                jobObject2.SetJobCpuLimit(9);
+                jobObject.SetJobCpuLimit(1 * 100);
+                jobObject2.SetJobCpuLimit(10 * 100);
 
                 var thread1 = new Thread(() =>
                 {
@@ -263,7 +263,7 @@ namespace IronFrame.Utilities
                 thread2.Join();
 
                 var ratio = (float)jobObject.GetCpuStatistics().TotalUserTime.Ticks / jobObject2.GetCpuStatistics().TotalUserTime.Ticks;
-                Assert.InRange(ratio, 0.05, 0.5);
+                Assert.InRange(ratio, 0.01, 0.2);
             }
 
             [Fact]
@@ -277,7 +277,7 @@ namespace IronFrame.Utilities
             public void ThrowsOnInvalidCpuWeights()
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => jobObject.SetJobCpuLimit(0));
-                Assert.Throws<ArgumentOutOfRangeException>(() => jobObject.SetJobCpuLimit(10));
+                Assert.Throws<ArgumentOutOfRangeException>(() => jobObject.SetJobCpuLimit(100 * 100 + 1));
             }
         }
 

--- a/IronFrame.TestHelper/Program.cs
+++ b/IronFrame.TestHelper/Program.cs
@@ -100,6 +100,28 @@ namespace IronFoundry.Warden.TestHelper
             return SUCCEEDED;
         }
 
+        static int ForkBomb()
+        {
+            try
+            {
+                var process = new Process();
+                process.StartInfo.FileName = System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName;
+                process.StartInfo.Arguments = "fork-bomb";
+                process.StartInfo.UseShellExecute = false;
+
+                if (!process.Start())
+                    return FAILED;
+
+                process.WaitForExit();
+            }
+            catch
+            {
+                return FAILED;
+            }
+
+            return SUCCEEDED;
+        }
+
         static void Main(string[] args)
         {
             if (args.Length == 0)
@@ -151,6 +173,10 @@ namespace IronFoundry.Warden.TestHelper
 
                     case "nop":
                         exitCode = SUCCEEDED;
+                        break;
+
+                    case "fork-bomb":
+                        exitCode = ForkBomb();
                         break;
 
                     default:

--- a/IronFrame/Container.cs
+++ b/IronFrame/Container.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using IronFrame.Utilities;
@@ -300,6 +301,11 @@ namespace IronFrame
         public void SetActiveProcessLimit(uint processLimit)
         {
             jobObject.SetActiveProcessLimit(processLimit);
+        }
+
+        public void SetPriorityClass(ProcessPriorityClass priority)
+        {
+            jobObject.SetPriorityClass(priority);
         }
     }
 }

--- a/IronFrame/Container.cs
+++ b/IronFrame/Container.cs
@@ -296,5 +296,10 @@ namespace IronFrame
         {
             return jobObject.GetJobCpuLimit();
         }
+
+        public void SetActiveProcessLimit(uint processLimit)
+        {
+            jobObject.SetActiveProcessLimit(processLimit);
+        }
     }
 }

--- a/IronFrame/IContainer.cs
+++ b/IronFrame/IContainer.cs
@@ -17,6 +17,7 @@ namespace IronFrame
         ulong CurrentMemoryLimit();
         void LimitCpu(int weight);
         int CurrentCpuLimit();
+        void SetActiveProcessLimit(uint processLimit);
         void SetProperty(string name, string value);
         string GetProperty(string name);
         Dictionary<string, string> GetProperties();

--- a/IronFrame/IContainer.cs
+++ b/IronFrame/IContainer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace IronFrame
@@ -18,6 +19,8 @@ namespace IronFrame
         void LimitCpu(int weight);
         int CurrentCpuLimit();
         void SetActiveProcessLimit(uint processLimit);
+        void SetPriorityClass(ProcessPriorityClass priority);
+
         void SetProperty(string name, string value);
         string GetProperty(string name);
         Dictionary<string, string> GetProperties();

--- a/build.bat
+++ b/build.bat
@@ -17,7 +17,7 @@ if (%TARGET%)==() set TARGET=Default
 for /F "tokens=1* delims= " %%a in ("%*") do set BUILDARGS=%%b
 if "%BUILDARGS%"=="" set BUILDARGS=/verbosity:minimal
 
-%MSBUILD% /nologo /m /nr:false /t:%TARGET% %BUILDARGS% %~dp0build/build.proj
+%MSBUILD% /nologo /nr:false /t:%TARGET% %BUILDARGS% %~dp0build/build.proj
 
 if errorlevel 1 goto Error_BuildFailed
 


### PR DESCRIPTION
- Change from Weight based CPU Limits to HardCaps
- Add Container#SetActiveProcessLimit to allow protecting against fork bombs