### PR TITLE
Disable name resolution in disk quota library

### DIFF
--- a/IronFrame.Test/ContainerServiceTests.cs
+++ b/IronFrame.Test/ContainerServiceTests.cs
@@ -52,6 +52,7 @@ namespace IronFrame
                 .ReturnsForAnyArgs(ContainerHostClient);
 
             UserManager.CreateUser(null).ReturnsForAnyArgs(new NetworkCredential("username", "password"));
+            UserManager.GetSID(null).ReturnsForAnyArgs("S-1234");
 
             diskQuotaManager = Substitute.For<IDiskQuotaManager>();
             diskQuotaControl = Substitute.For<DiskQuotaControl>();

--- a/IronFrame.Test/ContainerTests.cs
+++ b/IronFrame.Test/ContainerTests.cs
@@ -558,7 +558,7 @@ namespace IronFrame
             public void DeletesDiskQuota()
             {
                 var dskuser = Substitute.For<DIDiskQuotaUser>();
-                DiskQuotaControl.FindUser(User.UserName).Returns(dskuser);
+                DiskQuotaControl.FindUser(User.SID).Returns(dskuser);
 
                 Container.Destroy();
 
@@ -751,7 +751,7 @@ namespace IronFrame
             public void SetsUserDiskLimit()
             {
                 var quota = Substitute.For<DIDiskQuotaUser>();
-                this.DiskQuotaControl.AddUser(User.UserName).Returns(quota);
+                this.DiskQuotaControl.FindUser(User.SID).Returns(quota);
 
                 Container.LimitDisk(5);
 

--- a/IronFrame/Container.cs
+++ b/IronFrame/Container.cs
@@ -178,7 +178,7 @@ namespace IronFrame
         {
             try
             {
-                var dskuser = diskQuotaControl.FindUser(user.UserName);
+                var dskuser = diskQuotaControl.FindUser(user.SID);
                 diskQuotaControl.DeleteUser(dskuser);
             }
             catch (COMException)
@@ -320,7 +320,7 @@ namespace IronFrame
         public void LimitDisk(ulong limitInBytes)
         {
             ThrowIfNotActive();
-            var dskuser = diskQuotaControl.AddUser(user.UserName);
+            var dskuser = diskQuotaControl.FindUser(user.SID);
             dskuser.QuotaLimit = (double)limitInBytes;
         }
 

--- a/IronFrame/ContainerService.cs
+++ b/IronFrame/ContainerService.cs
@@ -192,8 +192,11 @@ namespace IronFrame
 
             var environment = new Dictionary<string, string>();
             var processHelper = new ProcessHelper();
+
             var diskQuotaControl = new DiskQuotaControl();
+            diskQuotaControl.UserNameResolution = UserNameResolutionConstants.dqResolveNone;
             diskQuotaControl.Initialize(directory.Volume, true);
+
             var dependencyHelper = new ContainerHostDependencyHelper();
 
             var container = new Container(

--- a/IronFrame/ContainerUser.cs
+++ b/IronFrame/ContainerUser.cs
@@ -35,9 +35,7 @@ namespace IronFrame
             {
                 if (_sid == null)
                 {
-                    var account = new NTAccount(UserName);
-                    var securityIdentifier = (SecurityIdentifier) account.Translate(typeof(SecurityIdentifier));
-                    _sid = securityIdentifier.ToString();
+                    _sid = userManager.GetSID(credentials.UserName);
                 }
                 return _sid;
             }

--- a/IronFrame/LocalPrincipalManager.cs
+++ b/IronFrame/LocalPrincipalManager.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Web.Security;
 using IronFrame.Utilities;
 using NLog;
+using System.Security.Principal;
 
 namespace IronFrame
 {
@@ -14,6 +15,7 @@ namespace IronFrame
     {
         NetworkCredential CreateUser(string userName);
         void DeleteUser(string userName);
+        string GetSID(string userName);
     }
 
     // Public because it is used by the acceptance tests to create/delete users.
@@ -69,6 +71,13 @@ namespace IronFrame
             }
 
             return new NetworkCredential(data.UserName, data.Password);
+        }
+
+        public string GetSID(string userName)
+        {
+            var account = new NTAccount(userName);
+            var securityIdentifier = (SecurityIdentifier)account.Translate(typeof(SecurityIdentifier));
+            return securityIdentifier.ToString();
         }
 
         public string FindUser(string userName)

--- a/IronFrame/Utilities/DiskQuotaManager.cs
+++ b/IronFrame/Utilities/DiskQuotaManager.cs
@@ -12,6 +12,7 @@ namespace IronFrame.Utilities
         public DiskQuotaControl CreateDiskQuotaControl(IContainerDirectory dir)
         {
             var diskQuotaControl = new DiskQuotaControl();
+            diskQuotaControl.UserNameResolution = UserNameResolutionConstants.dqResolveNone;
             diskQuotaControl.Initialize(dir.Volume, true);
             return diskQuotaControl;
         }


### PR DESCRIPTION
Rely only on SSID (not username) when interacting with the disk quota
library. This seams to improve the performance and is also
an attempt to make the quota enforcement integration tests more reliable.


This seems to improve the speed of lifecycle integration tests from ~ 1m50s to ~ 1m20s.

This types of failures should hopefully not happen:
```
• Failure [8.271 seconds]
Process limits a started process disk limits [It] streamed in data is enforced
C:/Users/Administrator/dwm2/src/github.com/cloudfoundry-incubator/garden-windows
/integration/lifecycle/limits_test.go:210

  Expected
      <uint64>: 7587840
  to be <
      <uint64>: 16384

  C:/Users/Administrator/dwm2/src/github.com/cloudfoundry-incubator/garden-windo
ws/integration/lifecycle/limits_test.go:209
```

```
Process limits
C:/Users/Administrator/dwm2/src/github.com/cloudfoundry-incubator/garden-windows
/integration/lifecycle/limits_test.go:213
  a started process
  C:/Users/Administrator/dwm2/src/github.com/cloudfoundry-incubator/garden-windo
ws/integration/lifecycle/limits_test.go:212
    disk limits
    C:/Users/Administrator/dwm2/src/github.com/cloudfoundry-incubator/garden-win
dows/integration/lifecycle/limits_test.go:211
      streamed in data is enforced [It]
      C:/Users/Administrator/dwm2/src/github.com/cloudfoundry-incubator/garden-w
indows/integration/lifecycle/limits_test.go:210

      Expected an error to have occurred.  Got:
          <nil>: nil

      C:/Users/Administrator/dwm2/src/github.com/cloudfoundry-incubator/garden-w
indows/integration/lifecycle/limits_test.go:206
```

I am opening a PR as there is no related issue on the tracker related to this. I will bump the submodule after the review and if it would be accepted.
