### PR TITLE
Splits ContainerMetrics and ContainerInfo into two separate structs

### DIFF
--- a/IronFrame.Test/ContainerTests.cs
+++ b/IronFrame.Test/ContainerTests.cs
@@ -614,10 +614,10 @@ namespace IronFrame
                 JobObject.GetProcessIds().Returns(new int[0]);
 
 
-                var info = Container.GetInfo();
+                var metrics = Container.GetMetrics();
 
-                Assert.Equal(TimeSpan.Zero, info.CpuStat.TotalProcessorTime);
-                Assert.Equal(0ul, info.MemoryStat.PrivateBytes);
+                Assert.Equal(TimeSpan.Zero, metrics.CpuStat.TotalProcessorTime);
+                Assert.Equal(0ul, metrics.MemoryStat.PrivateBytes);
             }
 
             [Fact]
@@ -646,10 +646,10 @@ namespace IronFrame
 
                 ProcessHelper.GetProcesses(null).ReturnsForAnyArgs(new[] { firstProcess, secondProcess });
 
-                var info = Container.GetInfo();
+                var metrics = Container.GetMetrics();
 
-                Assert.Equal(expectedTotalKernelTime + expectedTotalUserTime, info.CpuStat.TotalProcessorTime);
-                Assert.Equal((ulong)firstProcess.PrivateMemoryBytes + (ulong)secondProcess.PrivateMemoryBytes, info.MemoryStat.PrivateBytes);
+                Assert.Equal(expectedTotalKernelTime + expectedTotalUserTime, metrics.CpuStat.TotalProcessorTime);
+                Assert.Equal((ulong)firstProcess.PrivateMemoryBytes + (ulong)secondProcess.PrivateMemoryBytes, metrics.MemoryStat.PrivateBytes);
             }
 
             [Fact]
@@ -688,9 +688,9 @@ namespace IronFrame
                 JobObject.GetProcessIds().Returns(new int[] { 1 });
 
                 ProcessHelper.GetProcesses(null).ReturnsForAnyArgs(new[] { firstProcess });
-                var info = Container.GetInfo();
+                var metrics = Container.GetMetrics();
 
-                Assert.Equal(0ul, info.MemoryStat.PrivateBytes);
+                Assert.Equal(0ul, metrics.MemoryStat.PrivateBytes);
             }
         }
 

--- a/IronFrame/Container.cs
+++ b/IronFrame/Container.cs
@@ -239,19 +239,25 @@ namespace IronFrame
             {
                 ThrowIfDestroyed();
 
-                var ipAddress = IPUtilities.GetLocalIPAddress();
-                var ipAddressString = ipAddress != null ? ipAddress.ToString() : "";
-
                 return new ContainerInfo
                 {
-                    HostIPAddress = ipAddressString,
-                    ContainerIPAddress = ipAddressString,
-                    ContainerPath = directory.RootPath,
                     State = this.currentState,
+                    ReservedPorts = new List<int>(reservedPorts),
+                    Properties = propertyService.GetProperties(this),
+                };
+            }
+        }
+
+        public ContainerMetrics GetMetrics()
+        {
+            lock (_ioLock)
+            {
+                ThrowIfDestroyed();
+
+                return new ContainerMetrics
+                {
                     CpuStat = GetCpuStat(),
                     MemoryStat = GetMemoryStat(),
-                    Properties = propertyService.GetProperties(this),
-                    ReservedPorts = new List<int>(reservedPorts),
                 };
             }
         }

--- a/IronFrame/ContainerInfo.cs
+++ b/IronFrame/ContainerInfo.cs
@@ -8,21 +8,11 @@ namespace IronFrame
     {
         public ContainerInfo()
         {
-            CpuStat = new ContainerCpuStat();
-            Events = new List<string>();
-            MemoryStat = new ContainerMemoryStat();
             Properties = new Dictionary<string,string>();
             State = ContainerState.Born;
             ReservedPorts = new List<int>();
         }
 
-        public ContainerCpuStat CpuStat { get; set; }
-        public string ContainerIPAddress { get; set; }
-        public string ContainerPath { get; set; }
-        public List<string> Events { get; set; }
-        public string HostIPAddress { get; set; }
-        public ContainerMemoryStat MemoryStat { get; set; }
-        //public List<int> ProcessIds { get; set; }
         public Dictionary<string, string> Properties { get; set; }
         public List<int> ReservedPorts { get; set; }
         public ContainerState State { get; set; }
@@ -34,41 +24,12 @@ namespace IronFrame
             var otherPropertiesKeys = new HashSet<string>(other.Properties.Keys);
 
             return other != null &&
-                this.CpuStat.Equals(other.CpuStat) &&
-                String.Equals(ContainerIPAddress, other.ContainerIPAddress) &&
-                String.Equals(ContainerPath, other.ContainerPath, StringComparison.OrdinalIgnoreCase) &&
-                this.Events.SequenceEqual(other.Events, StringComparer.OrdinalIgnoreCase) &&
-                String.Equals(HostIPAddress, other.HostIPAddress) &&
-                this.MemoryStat.Equals(other.MemoryStat) &&
                 this.ReservedPorts.SequenceEqual(other.ReservedPorts) &&
                 //thisPropertiesKeys.Equals(otherPropertiesKeys) &&
                 State.Equals(other.State);
         }
     }
 
-    public sealed class ContainerCpuStat : IEquatable<ContainerCpuStat>
-    {
-        public TimeSpan TotalProcessorTime { get; set; }
-
-        // BR: This makes me sad. These are only used for unit tests :(
-        public bool Equals(ContainerCpuStat other)
-        {
-            return other != null &&
-                this.TotalProcessorTime == other.TotalProcessorTime;
-        }
-    }
-
-    public sealed class ContainerMemoryStat : IEquatable<ContainerMemoryStat>
-    {
-        public ulong PrivateBytes { get; set; }
-
-        // BR: This makes me sad. These are only used for unit tests :(
-        public bool Equals(ContainerMemoryStat other)
-        {
-            return other != null &&
-                this.PrivateBytes == other.PrivateBytes;
-        }
-    }
 
     public enum ContainerState
     {

--- a/IronFrame/ContainerMetrics.cs
+++ b/IronFrame/ContainerMetrics.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace IronFrame
+{
+    public sealed class ContainerMetrics  
+    {
+        public ContainerMetrics()
+        {
+            MemoryStat = new ContainerMemoryStat();
+            CpuStat = new ContainerCpuStat();
+        }
+
+        public ContainerCpuStat CpuStat { get; set; }
+        public ContainerMemoryStat MemoryStat { get; set; }
+    }
+
+    public sealed class ContainerCpuStat : IEquatable<ContainerCpuStat>
+    {
+        public TimeSpan TotalProcessorTime { get; set; }
+
+        // BR: This makes me sad. These are only used for unit tests :(
+        public bool Equals(ContainerCpuStat other)
+        {
+            return other != null &&
+                this.TotalProcessorTime == other.TotalProcessorTime;
+        }
+    }
+
+    public sealed class ContainerMemoryStat : IEquatable<ContainerMemoryStat>
+    {
+        public ulong PrivateBytes { get; set; }
+
+        // BR: This makes me sad. These are only used for unit tests :(
+        public bool Equals(ContainerMemoryStat other)
+        {
+            return other != null &&
+                this.PrivateBytes == other.PrivateBytes;
+        }
+    }
+}

--- a/IronFrame/IContainer.cs
+++ b/IronFrame/IContainer.cs
@@ -40,6 +40,7 @@ namespace IronFrame
         void CreateOutboundFirewallRule(FirewallRuleSpec firewallRuleSpec);
         ulong CurrentDiskLimit();
         ulong CurrentDiskUsage();
+        ContainerMetrics GetMetrics();
     }
 
     public interface IProcessIO

--- a/IronFrame/IronFrame.csproj
+++ b/IronFrame/IronFrame.csproj
@@ -63,6 +63,7 @@
     <Compile Include="BindMount.cs" />
     <Compile Include="ContainerHandleHelper.cs" />
     <Compile Include="ContainerInfo.cs" />
+    <Compile Include="ContainerMetrics.cs" />
     <Compile Include="IContainerProcess.cs" />
     <Compile Include="IContainerDirectory.cs" />
     <Compile Include="ConstrainedProcess.cs" />


### PR DESCRIPTION
Previously GetInfo returned both the container info as well as the metrics.
metrics turned out to be expensive, this change is separating them. It also
removes some unused ContainerInfo fields, e.g. HostIpAddress. Some of those
fields required looping through the network interfaces and figuring out
the ip address. although we could possibly cache the information it seems
unecessary to do the effort given that the containerizer doesn't use them.

[#105015120]

Signed-off-by: Micah Young <myoung@pivotal.io>